### PR TITLE
Worker process improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 - Network calls now use a custom user agent `Social-Relay/<version> - https://github.com/jaywink/social-relay`. Thanks @bmanojlovic for the patch.
 - Relay also Diaspora `retraction` and `photo` entities. The former follows the same way `like` and `comment` entities are relayed, ie the targets are the same as where the `status_message` or `photo` were relayed. `photo` follows same rules as `status_message` entities, ie according to subscriber wishes.
 
+### Changed
+- Replaced custom payload sending with the new helper from `federation`. This will not try to deliver to `http` targets at all. This means nodes that are not using https will not get deliveries. Really, these days, there is no reason to run a public website with http.
+
 ### Removed
 - Removed suggestion to use `pip-tools` and convert requirements files to standard Python project requirements files. Didn't dig the workflow after all. To install dev dependencies use `requirements/development.txt`. For production, use `requirements/production.txt`, which also contains `uWSGI`. If you don't deploy using uWSGI, you can just use `requirements/requirements.txt`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ### Added
 - Expose [NodeInfo](https://github.com/jhass/nodeinfo) to allow registering relays to pod lists. Unfortunately, NodeInfo schema doesn't contain the relay software key so this NodeInfo document cannot be validated by consumers.
-- Network calls now use a custom user agent `Social-Relay/<version> - https://github.com/jaywink/social-relay`.
+- Network calls now use a custom user agent `Social-Relay/<version> - https://github.com/jaywink/social-relay`. Thanks @bmanojlovic for the patch.
+- Relay also Diaspora `retraction` and `photo` entities. The former follows the same way `like` and `comment` entities are relayed, ie the targets are the same as where the `status_message` or `photo` were relayed. `photo` follows same rules as `status_message` entities, ie according to subscriber wishes.
 
 ### Removed
 - Removed suggestion to use `pip-tools` and convert requirements files to standard Python project requirements files. Didn't dig the workflow after all. To install dev dependencies use `requirements/development.txt`. For production, use `requirements/production.txt`, which also contains `uWSGI`. If you don't deploy using uWSGI, you can just use `requirements/requirements.txt`.

--- a/workers/receive.py
+++ b/workers/receive.py
@@ -1,16 +1,13 @@
 # -*- coding: utf-8 -*-
 import datetime
 import logging
-from _socket import timeout
-
-import requests
-from peewee import DoesNotExist
-from requests.exceptions import ConnectionError, Timeout
 
 from federation.entities.base import Image
 from federation.entities.diaspora.entities import DiasporaPost, DiasporaLike, DiasporaComment, DiasporaRetraction
 from federation.exceptions import NoSuitableProtocolFoundError
 from federation.inbound import handle_receive
+from federation.utils.network import send_document
+from peewee import DoesNotExist
 
 from social_relay import config
 from social_relay.models import Node, Post
@@ -21,48 +18,6 @@ from social_relay.utils.statistics import log_worker_receive_statistics
 SUPPORTED_ENTITIES = (
     DiasporaPost, DiasporaLike, DiasporaComment, DiasporaRetraction, Image
 )
-
-
-def send_payload(host, payload):
-    """Post payload to host, try https first, fall back to http.
-
-    Return a dictionary containing:
-        "result": True or False, depending on success of operation.
-        "https": True or False
-
-    Timeouts or connection errors will not be raised.
-    """
-    logging.info("Sending payload to %s" % host)
-    https = True
-    try:
-        try:
-            response = requests.post(
-                "https://%s/receive/public" % host,
-                data={"xml": payload},
-                headers={"User-Agent": config.USER_AGENT},
-                timeout=10,
-                allow_redirects=False
-            )
-            logging.debug("protocol=https host=%s result=%s" % (host, response.status_code))
-        except timeout:
-            logging.debug("protocol=https host=%s result=timeout" % host)
-            response = False
-        if not response or response.status_code not in [200, 202]:
-            https = False
-            response = requests.post(
-                "http://%s/receive/public" % host,
-                data={"xml": payload},
-                headers={"User-Agent": config.USER_AGENT},
-                timeout=10,
-                allow_redirects=False
-            )
-            logging.debug("protocol=http host=%s result=%s" % (host, response.status_code))
-            if response.status_code not in [200, 202]:
-                return {"result": False, "https": https}
-    except (ConnectionError, Timeout) as ex:
-        logging.debug("Connection failed with {host}: {ex}".format(host=host, ex=ex))
-        return {"result": False, "https": https}
-    return {"result": True, "https": https}
 
 
 def save_post_metadata(entity, protocol, hosts):
@@ -133,13 +88,18 @@ def process(payload):
                 nodes = get_send_to_nodes(sender, entity)
                 # Send out
                 for node in nodes:
-                    response = send_payload(node, payload)
-                    if response["result"]:
+                    status, error = send_document(
+                        url="https://%s/receive/public" % node,
+                        data={"xml": payload},
+                        headers={"User-Agent": config.USER_AGENT},
+                    )
+                    is_success = status in [200, 202]
+                    if is_success:
                         sent_success += 1
                         sent_to_nodes.append(node)
                     sent_amount += 1
-                    update_node(node, response)
-                if sent_to_nodes and isinstance(entity, DiasporaPost):
+                    update_node(node, is_success)
+                if sent_to_nodes and isinstance(entity, (DiasporaPost, Image)):
                     save_post_metadata(entity=entity, protocol=protocol_name, hosts=sent_to_nodes)
     finally:
         log_worker_receive_statistics(
@@ -147,24 +107,25 @@ def process(payload):
         )
 
 
-def update_node(pod, response):
+def update_node(node, success):
     """Update Node in database
 
-    :param pod: Hostname
-    :param response: Dictionary with booleans "result" and "https"
+    :param node: Hostname
+    :param success: Was the last call a success (bool)
     """
     try:
-        Node.get_or_create(host=pod)
-        if response["result"]:
+        Node.get_or_create(host=node)
+        if success:
             # Update delivered_count and last_success, nullify failure_count
+            # TODO: remove the whole https tracking - we're only delivering to https now
             Node.update(
                 last_success=datetime.datetime.now(), total_delivered=Node.total_delivered + 1,
-                failure_count=0, https=response["https"]).where(Node.host==pod).execute()
+                failure_count=0, https=True).where(Node.host == node).execute()
         else:
             # Update failure_count
             Node.update(
-                failure_count=Node.failure_count + 1).where(Node.host==pod).execute()
+                failure_count=Node.failure_count + 1).where(Node.host == node).execute()
     except Exception as ex:
         logging.warning("Exception when trying to save or update Node {node} into database: {exc}".format(
-            node=pod, exc=ex)
+            node=node, exc=ex)
         )


### PR DESCRIPTION
- Use federation send_document helper to send payloads. Replaced custom payload sending with the new helper from 'federation'. This will not try to deliver to 'http' targets at all. This means nodes that are not using https will not get deliveries. Really, these days, there is no reason to run a public website with http.
- Also relay DiasporaRetraction and Image. Closes #40
