### PR TITLE
Profiles and new style Diaspora public payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [unreleased]
+
+### Added
+* Accept new style Diaspora public payloads without `xml=payload` form data.
+* Add profile model. Store remote profile handle + public key for later use, since we don't want to always fetch them.
+* Start validating signatures in sent payloads. This requires fetching remote profiles. Closes #[31](https://github.com/jaywink/social-relay/issues/31).
+
 ## [1.3.3] - 2017-03-10
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -184,6 +184,10 @@ The app will be running at [http://127.0.0.1:5000](http://127.0.0.1:5000).
 
 ### Running tests
 
+Ensure there is a test database. By default the tests try to connect to PostgreSQL with db, username and password `socialrelaytest`.
+
+Then run test with:
+
     py.test
 
 ## Author

--- a/arnold_config/migrations/003_add_profile.py
+++ b/arnold_config/migrations/003_add_profile.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+from social_relay.config import database
+from social_relay.models import Profile
+
+tables = [Profile]
+
+
+def up():
+    database.create_tables(tables)
+
+
+def down():
+    database.drop_tables(tables)

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -7,11 +7,12 @@ hiredis==0.2.0
 redis==2.10.5
 
 # federation
-federation==0.10.1
+federation==0.13.0
 
 # generic
 requests==2.12.4
 schedule==0.4.2
+bleach==2.0.0
 
 # background jobs
 rq==0.7.1

--- a/social_relay/models.py
+++ b/social_relay/models.py
@@ -92,7 +92,7 @@ class Profile(database.Model):
         """Create a Profile from a remote Profile entity."""
         public_key = safe_text(remote_profile.public_key)
         profile, created = Profile.get_or_create(
-            handle=safe_text(remote_profile.handle),
+            identifier=safe_text(remote_profile.handle),
             defaults={
                 "public_key": public_key,
             },

--- a/social_relay/templates/index.html
+++ b/social_relay/templates/index.html
@@ -21,6 +21,8 @@
             <div class="col-xs-12 col-sm-6 placeholder">
                 <h4>Distinct nodes delivered to</h4>
                 <span class="text-muted">{{ distinct_nodes.all }}</span>
+                <h4>Distinct sender profiles</h4>
+                <span class="text-muted">{{ profiles.all }}</span>
             </div>
         </div>
 

--- a/social_relay/tests/conftest.py
+++ b/social_relay/tests/conftest.py
@@ -2,7 +2,7 @@
 import pytest
 from peewee import ProgrammingError, OperationalError
 
-from social_relay.models import create_all_tables, drop_all_tables
+from social_relay.models import create_all_tables, drop_all_tables, Profile
 
 
 @pytest.fixture
@@ -20,3 +20,8 @@ def app(request):
     request.addfinalizer(drop_db)
 
     return app
+
+
+@pytest.fixture
+def profile(app):
+    return Profile.create(identifier="relay@domain.tld", public_key="public_key")

--- a/social_relay/tests/test_models.py
+++ b/social_relay/tests/test_models.py
@@ -1,0 +1,32 @@
+from unittest.mock import patch, Mock
+
+from social_relay.models import Profile
+
+
+class TestProfile:
+    def test_get_public_key(self, profile):
+        assert Profile.get_public_key(profile.identifier) == profile.public_key
+
+    @patch("social_relay.models.retrieve_remote_profile", return_value=None)
+    def test_get_profile(self, mock_retrieve, profile):
+        # Local
+        assert Profile.get_profile(profile.identifier) == profile
+
+        # Not existing
+        assert not Profile.get_profile("foobar")
+        mock_retrieve.assert_called_once_with("foobar")
+
+    def test_from_remote_profile(self, profile):
+        # New
+        new_profile = Profile.from_remote_profile(Mock(
+            handle="identifier", public_key="public_key",
+        ))
+        assert new_profile.identifier == "identifier"
+        assert new_profile.public_key == "public_key"
+
+        # Existing
+        Profile.from_remote_profile(Mock(
+            handle=profile.identifier, public_key="new public key",
+        ))
+        profile = Profile.get(Profile.identifier == profile.identifier)
+        assert profile.public_key == "new public key"

--- a/social_relay/tests/test_views.py
+++ b/social_relay/tests/test_views.py
@@ -6,7 +6,7 @@ import pytest
 
 
 @pytest.mark.usefixtures('client_class')
-class TestViewsRespond(object):
+class TestViewsRespond:
     def test_index(self, client):
         assert client.get(url_for('index')).status_code == 200
 
@@ -26,11 +26,12 @@ class TestViewsRespond(object):
     def test_hcard_returns_200_with_relay_guid(self, client):
         assert client.get(url_for('webfinger', guid="jvfhieuhfuih78fhf8uibhfhuyweyfdu")).status_code == 404
 
-    def test_receive_public_returns_404_without_xml_content(self, client):
+    def test_receive_public_returns_404_without_payload(self, client):
         assert client.post(url_for("receive_public")).status_code == 404
 
-    def test_receive_public_returns_200_with_xml_content(self, client):
+    def test_receive_public_returns_200_with_payload(self, client):
         assert client.post(url_for("receive_public"), data={"xml": "foo"}).status_code == 200
+        assert client.post(url_for("receive_public"), data="<foo>bar</foo>").status_code == 200
 
     def test_nodeinfo_wellknown(self, client):
         assert client.get(url_for('nodeinfo_wellknown')).status_code == 200
@@ -40,7 +41,7 @@ class TestViewsRespond(object):
 
 
 @pytest.mark.usefixtures('client_class')
-class TestViewsCallStatisticsLoggers(object):
+class TestViewsCallStatisticsLoggers:
     @patch("social_relay.views.log_receive_statistics")
     def test_receive_public_calls_log_receive_statistics(self, mock_statistics, client):
         client.post(url_for("receive_public"), data={"xml": "foo"})

--- a/social_relay/utils/statistics.py
+++ b/social_relay/utils/statistics.py
@@ -2,7 +2,7 @@
 import datetime
 import json
 
-from social_relay.models import ReceiveStatistic, WorkerReceiveStatistic, Node
+from social_relay.models import ReceiveStatistic, WorkerReceiveStatistic, Node, Profile
 from social_relay.utils.data import get_pod_preferences
 from social_relay.utils.queues import public_queue, get_worker_count
 
@@ -53,13 +53,15 @@ def get_count_stats():
     }
     distinct_nodes = {
         "all": Node.select().count(),
-        "https": Node.select().where(Node.https==True).count(),
     }
     processing = {
         "workers": get_worker_count(),
         "queue_jobs": len(public_queue),
     }
-    return incoming, outgoing, distinct_nodes, processing
+    profiles = {
+        "all": Profile.select().count(),
+    }
+    return incoming, outgoing, distinct_nodes, processing, profiles
 
 
 def log_receive_statistics(sender_host):

--- a/social_relay/utils/text.py
+++ b/social_relay/utils/text.py
@@ -1,0 +1,6 @@
+import bleach
+
+
+def safe_text(text):
+    """Clean text, stripping all tags, attributes and styles."""
+    return bleach.clean(text, tags=[], attributes=[], styles=[], strip=True)

--- a/social_relay/views.py
+++ b/social_relay/views.py
@@ -27,7 +27,7 @@ Bower(app)
 @app.route('/')
 def index():
     subscriber_stats = get_subscriber_stats()
-    incoming, outgoing, distinct_nodes, processing = get_count_stats()
+    incoming, outgoing, distinct_nodes, processing, profiles = get_count_stats()
     return render_template(
         'index.html',
         config=app.config,
@@ -36,6 +36,7 @@ def index():
         outgoing_counts=outgoing,
         distinct_nodes=distinct_nodes,
         processing=processing,
+        profiles=profiles,
     )
 
 

--- a/social_relay/views.py
+++ b/social_relay/views.py
@@ -106,9 +106,14 @@ def hcard(guid):
 @app.route("/receive/public/", methods=["POST"])
 @app.route("/receive/public", methods=["POST"])
 def receive_public():
+    payload = ""
     try:
+        # Legacy payloads
         payload = request.form["xml"]
     except KeyError:
+        if request.data:
+            payload = request.data
+    if not payload:
         return abort(404)
     # Queue to rq for processing
     public_queue.enqueue("workers.receive.process", payload, timeout=app.config.get("RELAY_WORKER_TIMEOUT"))
@@ -118,7 +123,7 @@ def receive_public():
 
     # return 200 whatever
     data = {
-        'result'  : 'ok',
+        'result': 'ok',
     }
     js = json.dumps(data)
     return Response(js, status=200, mimetype='application/json')


### PR DESCRIPTION
Accept new style Diaspora public payloads without form data.

Bump federation which has new relayable signature verification code when processing payloads to entities. This forces us to finally implement verifying payloads, and thus we need to fetch remote profiles.

Add profile model. Store remote profile handle + public key for later use, since we don't want to always fetch them.

Drive-by closes #31.

TODO:
* [x] Tests
